### PR TITLE
Add basic page load animations

### DIFF
--- a/assets/js/animations.js
+++ b/assets/js/animations.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const timeline = anime.timeline({ easing: 'easeOutExpo', duration: 750 });
+
+  timeline
+    .add({
+      targets: 'h1',
+      opacity: [0, 1],
+      translateY: [-20, 0]
+    })
+    .add({
+      targets: 'img[alt="Peter Galenko"]',
+      opacity: [0, 1],
+      scale: [0.8, 1]
+    }, '-=400')
+    .add({
+      targets: 'nav a',
+      opacity: [0, 1],
+      translateY: [10, 0],
+      delay: anime.stagger(100)
+    }, '-=400');
+});

--- a/index.html
+++ b/index.html
@@ -64,6 +64,8 @@
     <!-- Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="shortcut icon" href="./assets/images/favicon.ico" type="image/x-icon">
+    <!-- Anime.js -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
 </head>
 <body class="bg-pattern text-gray-100 font-sans">
     <!-- Language Switcher (Fixed) -->
@@ -901,5 +903,6 @@ submitBtn.disabled = false;
 
 </script>
 <script src="https://cdn.tailwindcss.com"></script>
+<script src="./assets/js/animations.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Anime.js from CDN
- animate heading, avatar, and navigation on page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad75c6f13c8322a9388fd56999a87a